### PR TITLE
JPERF-1454 Fix JDK installation on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/docker-infrastructure/compare/release-0.3.7...master
 
+### Fixed
+- Fix java installation on MacOS. Aid [JPERF-1454]
+
+[JPERF-1454]: https://ecosystem.atlassian.net/browse/JPERF-1454
+ 
 ## [0.3.7] - 2023-09-12
 [0.3.7]: https://github.com/atlassian/docker-infrastructure/compare/release-0.3.6...release-0.3.7
 

--- a/src/main/kotlin/com/atlassian/performance/tools/dockerinfrastructure/api/jira/AbstractJiraFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/dockerinfrastructure/api/jira/AbstractJiraFormula.kt
@@ -46,7 +46,6 @@ abstract class AbstractJiraFormula internal constructor(
                         .run("tar", "-xzf", "atlassian-jira-$jiraVariant-$version.tar.gz")
                         .run("rm", "/atlassian-jira-$jiraVariant-$version-standalone/bin/check-java.sh")
                         .run("mkdir", "jira-home")
-                        .env("JAVA_HOME", "/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre")
                         .env("JIRA_HOME", "/jira-home")
                         .cmd("/atlassian-jira-$jiraVariant-$version-standalone/bin/start-jira.sh", "-fg")
                         .build()


### PR DESCRIPTION
Docker fetches images based on architecture.
It means previously actual image downloaded was 'amd64/ubuntu:20.04' when running on am64 architecture.

When image 'ubuntu:20.04' was used on MacOS, fetched image was 'arm64v8/ubuntu:20.04' and JAVA_HOME was broken

JAVA_HOME is set up properly without setting it explicitly