### PR TITLE
Fix `shouldBeSeenByAnotherDocker` on Mac

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/dockerinfrastructure/api/browser/DockerisedChrome.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/dockerinfrastructure/api/browser/DockerisedChrome.kt
@@ -35,7 +35,6 @@ class DockerisedChrome(
         override val driver: RemoteWebDriver = container.webDriver
 
         override fun close() {
-            driver.quit()
             container.afterTest(
                 object : TestDescription {
                     override fun getFilesystemFriendlyName(): String = UUID.randomUUID().toString()
@@ -43,6 +42,7 @@ class DockerisedChrome(
                 },
                 Optional.empty()
             )
+            driver.quit()
             container.close()
         }
     }


### PR DESCRIPTION
Avoid:
```
com.github.dockerjava.api.exception.ConflictException: Status 409: {"message":"container 66ef963ea538fd8ba7aea54af20053589e4be56a7dc852e5fbdd9e8d86613eff is not running"}

	at org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:245)
	at org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.post(DefaultInvocationBuilder.java:124)
	at org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec.execute(ExecCreateCmdExec.java:30)
	at org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec.execute(ExecCreateCmdExec.java:13)
	at org.testcontainers.shaded.com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
	at org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
	at org.testcontainers.shaded.com.github.dockerjava.core.command.ExecCreateCmdImpl.exec(ExecCreateCmdImpl.java:172)
	at org.testcontainers.shaded.com.github.dockerjava.core.command.ExecCreateCmdImpl.exec(ExecCreateCmdImpl.java:12)
	at org.testcontainers.containers.ExecInContainerPattern.execInContainer(ExecInContainerPattern.java:108)
	at org.testcontainers.containers.ContainerState.execInContainer(ContainerState.java:247)
	at org.testcontainers.containers.ContainerState.execInContainer(ContainerState.java:237)
	at org.testcontainers.containers.VncRecordingContainer$VncRecordingFormat$2.reencodeRecording(VncRecordingContainer.java:149)
	at org.testcontainers.containers.VncRecordingContainer.streamRecording(VncRecordingContainer.java:117)
	at org.testcontainers.containers.VncRecordingContainer.saveRecordingToFile(VncRecordingContainer.java:128)
	at org.testcontainers.containers.BrowserWebDriverContainer.retainRecordingIfNeeded(BrowserWebDriverContainer.java:395)
	at org.testcontainers.containers.BrowserWebDriverContainer.afterTest(BrowserWebDriverContainer.java:346)
	at com.atlassian.performance.tools.dockerinfrastructure.api.browser.DockerisedChrome$ContainerBrowser.close(DockerisedChrome.kt:39)
	at kotlin.jdk7.AutoCloseableKt.closeFinally(AutoCloseable.kt:56)
	at com.atlassian.performance.tools.dockerinfrastructure.api.jira.AbstractJiraFormula.provisionJira(AbstractJiraFormula.kt:82)
	at com.atlassian.performance.tools.dockerinfrastructure.api.jira.AbstractJiraFormula.provision(AbstractJiraFormula.kt:67)
	at com.atlassian.performance.tools.dockerinfrastructure.AbstractJiraFormulaIT.build(AbstractJiraFormulaIT.kt:12)
	at com.atlassian.performance.tools.dockerinfrastructure.JiraCoreFormulaIT.shouldBeSeenByAnotherDocker(JiraCoreFormulaIT.kt:11)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:413)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.lang.Thread.run(Thread.java:750)
```

It tried to `docker exec` in order to gather the recording file. But we `driver.quit` beforehand, which is the entrypoint, so stopping the process stopped the container. It was a race condition between the innate stop and the exec.