### PR TITLE
Upload diagnoses in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           arguments: build
         timeout-minutes: 20
+      - name: Upload diagnoses
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.run }}-diagnoses
+          path: build/diagnoses
   build-check:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
This should give us diagnoses (screenshots, logs, HTML) when the CI goes red. I could fabricate a red build to demonstrate it, but I'm too lazy today :P