### PR TITLE
Work around `publish` Dokka problem

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,10 @@ val testContainersVersion = "1.17.5"
 val log4jVersion = "2.17.2"
 
 plugins {
+    // gradle-release has to go first, see https://github.com/atlassian-labs/gradle-release/pull/5/commits/0e89b0646d3393e5cf2827240d64bc9bdc2060c1
+    id("com.atlassian.performance.tools.gradle-release").version("0.9.0")
     kotlin("jvm").version("1.3.20")
     `java-library`
-    id("com.atlassian.performance.tools.gradle-release").version("0.9.0")
 }
 
 configurations.all {


### PR DESCRIPTION
It was discovered using the gradle-release devloop: https://github.com/atlassian-labs/gradle-release/commit/806c3346afd61ace76ef501e2aa6a7526b0a7bd8

Here, in Docker infra, it was locally confirmed by `publishToMavenLocal --stacktrace`.

Before:
```
* What went wrong:
org/jetbrains/kotlin/gradle/dsl/KotlinSingleTargetExtension
> org.jetbrains.kotlin.gradle.dsl.KotlinSingleTargetExtension

* Try:
> Run with --info or --debug option to get more log output.

* Exception is:
java.lang.NoClassDefFoundError: org/jetbrains/kotlin/gradle/dsl/KotlinSingleTargetExtension
        at org.jetbrains.dokka.gradle.kotlin.KotlinCompilationUtilsKt.allCompilationsOf(kotlinCompilationUtils.kt:25)
        at org.jetbrains.dokka.gradle.kotlin.IsMainSourceSetKt.isMainSourceSet(isMainSourceSet.kt:10)
        at org.jetbrains.dokka.gradle.kotlin.KotlinSourceSetGistKt$gistOf$2.call(KotlinSourceSetGist.kt:21)
        at org.jetbrains.dokka.gradle.kotlin.KotlinSourceSetGistKt$gistOf$2.call(KotlinSourceSetGist.kt)
        at org.gradle.api.internal.provider.DefaultProvider.calculateOwnValue(DefaultProvider.java:72)

BUILD FAILED in 11s
```

After:
```
BUILD SUCCESSFUL in 4s
10 actionable tasks: 4 executed, 6 up-to-date
```